### PR TITLE
Fix reinvestment scaling

### DIFF
--- a/common/defines/01_reinvestment_override.txt
+++ b/common/defines/01_reinvestment_override.txt
@@ -1,0 +1,4 @@
+NCountry = {
+        REINVESTMENT_EFFICIENCY_MAX = 1.0                             # Keep reinvestment constant
+        REINVESTMENT_BASE_EFFICIENCY_THRESHOLD = 0                    # Disable GDP scaling
+}


### PR DESCRIPTION
## Summary
- override reinvestment defines so GDP no longer increases reinvestment

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687563b574fc832ea97e860fee3e6067