### PR TITLE
Enable slave labor across building groups

### DIFF
--- a/common/building_groups/00_building_groups.txt
+++ b/common/building_groups/00_building_groups.txt
@@ -1,0 +1,864 @@
+﻿# parent_group = parent_group_key		If set, this group is considered a child of the specified group. Default no parent.
+# always_possible = yes/no				If yes, building types in this group are always permitted regardless of resources in state. Default no.
+# economy_of_scale = yes/no				If yes, any non-subsistence buildings in or underneath this group will get an economy of scale throughput modifier for each level > 1. Default no.
+# is_subsistence = yes/no				If yes, buildings of types in this group are considered subsistence buildings that follow special rules. Default no.
+# default_building = building_type_key	Specifies the default building type that will be built unless the state specifies a different one. No default.
+# lens = lens_key						If specified, determines the lens buildings in this group will be sorted under. No default.
+# auto_place_buildings = yes/no
+# capped_by_resources = yes/no
+# discoverable_resource = yes/no
+# depletable_resource = yes/no
+# can_use_slaves = yes/no				Default no, setting yes enables slavery for all contained buildings and groups
+# land_usage = urban/rural				Which type of state resource the building uses. urban = Urbanization, rural = Arable Land. Default no state resource usage.
+#										If unspecified, will return first non-default land usage type found in parent building group tree.
+# cash_reserves_max = number			Maximum amount of £ (per level) that buildings in this group can store into their cash reserves. If unspecified or set to 0, it will use the value from the parent group. Default 0
+# inheritable_construction =  yes/no	If yes, a construction of this building group will survive a state changing hands or a split state merging
+# stateregion_max_level = yes/no		If yes, any building types in this group with the has_max_level property will consider its level restrictions on state-region rather than state level
+# urbanization = number					The amount of urbanization buildings in this group provides per level
+# should_auto_expand = trigger			Under which condition buildings in this group should auto-expand if auto-expand is toggled on (trigger on more specific group or building type overrides)
+# 										If this trigger has any contents at all, the game will think the building is potentially auto-expandable, so do not write triggers that can never evaluate to true here
+# min_hiring_rate = X					Minimum value for how much of the building's max staffing level can be hired in a single week (default NDefines::NEconomy::DEFAULT_MIN_HIRING_RATE)
+# max_hiring_rate = X					Maximum value for how much of the building's max staffing level can be hired in a single week (default NDefines::NEconomy::DEFAULT_MAX_HIRING_RATE)
+# proportionality_limit = X				How high is the building's tolerance for pop types being out of proportion? default NDefines::NEconomy::EMPLOYMENT_PROPORTIONALITY_LIMIT)
+# hires_unemployed_only = yes			If yes, buildings in this group may only hire from the unemployment pool. Default no.
+# is_shown_in_outliner = yes			If no, buildingtypes in this group will not show up in the outliner, this is for special stuff like the monuments
+# subsidized = yes						If yes, buildings of this group will by default start the game subsidized (has no effect after campaign start)
+# Manufacturing
+
+bg_manufacturing = {
+	category = urban
+
+	always_possible = yes
+
+	economy_of_scale = yes
+
+	cash_reserves_max = 25000
+
+	should_auto_expand = {
+		default_auto_expand_rule = yes
+	}
+
+	economy_of_scale_ai_factor = 2.0
+	foreign_investment_ai_factor = 0.25
+    can_use_slaves = yes
+}
+
+bg_light_industry = {
+	parent_group = bg_manufacturing
+
+	lens = light_industry
+
+	urbanization = 20
+	infrastructure_usage_per_level = 2
+    can_use_slaves = yes
+}
+
+bg_heavy_industry = {
+	parent_group = bg_manufacturing
+
+	lens = heavy_industry
+
+	urbanization = 20
+	infrastructure_usage_per_level = 3
+    can_use_slaves = yes
+}
+
+bg_shipyards = {
+	parent_group = bg_heavy_industry
+
+	urbanization = 20
+	infrastructure_usage_per_level = 1
+    can_use_slaves = yes
+}
+
+bg_military_shipyards = {
+	parent_group = bg_heavy_industry
+
+	urbanization = 20
+	infrastructure_usage_per_level = 2
+    can_use_slaves = yes
+}
+
+bg_artillery_foundaries = {
+	parent_group = bg_light_industry
+
+	urbanization = 20
+	infrastructure_usage_per_level = 2
+    can_use_slaves = yes
+}
+
+bg_arms_industries = {
+	parent_group = bg_light_industry
+
+	urbanization = 20
+	infrastructure_usage_per_level = 2
+    can_use_slaves = yes
+}
+
+bg_munition_plants = {
+	parent_group = bg_heavy_industry
+
+	urbanization = 20
+	infrastructure_usage_per_level = 3
+    can_use_slaves = yes
+}
+
+# Agriculture
+
+bg_agriculture = {
+	category = rural
+
+	land_usage = rural
+
+	lens = agriculture
+
+	economy_of_scale = yes
+
+
+	urbanization = 5
+	infrastructure_usage_per_level = 1
+
+	should_auto_expand = {
+		default_auto_expand_rule = yes
+	}
+
+	economy_of_scale_ai_factor = 1.5
+	foreign_investment_ai_factor = 0.75
+    can_use_slaves = yes
+}
+
+bg_rye_farms = {
+	parent_group = bg_agriculture
+
+	default_building = building_rye_farm
+
+	cash_reserves_max = 25000
+    can_use_slaves = yes
+}
+
+bg_wheat_farms = {
+	parent_group = bg_agriculture
+
+	default_building = building_wheat_farm
+
+	cash_reserves_max = 25000
+    can_use_slaves = yes
+}
+
+bg_rice_farms = {
+	parent_group = bg_agriculture
+
+	default_building = building_rice_farm
+
+	cash_reserves_max = 25000
+    can_use_slaves = yes
+}
+
+bg_maize_farms = {
+	parent_group = bg_agriculture
+
+	default_building = building_maize_farm
+
+	cash_reserves_max = 25000
+    can_use_slaves = yes
+}
+
+bg_millet_farms = {
+	parent_group = bg_agriculture
+
+	default_building = building_millet_farm
+
+	cash_reserves_max = 25000
+    can_use_slaves = yes
+}
+
+
+bg_subsistence_agriculture = {
+	parent_group = bg_agriculture
+
+	always_possible = yes
+
+	auto_place_buildings = yes
+
+	is_subsistence = yes
+
+	default_building = building_subsistence_farms
+
+	fired_pops_become_radical = no
+
+	hires_unemployed_only = yes
+
+	ignores_productivity_when_hiring = yes
+    can_use_slaves = yes
+}
+
+bg_vineyard_plantations = {
+	parent_group = bg_agriculture
+
+	default_building = building_vineyard_plantation
+
+	cash_reserves_max = 25000
+    can_use_slaves = yes
+}
+
+# Ranching
+
+bg_ranching = {
+	category = rural
+
+	land_usage = rural
+
+	lens = agriculture
+
+	economy_of_scale = yes
+
+
+	urbanization = 5
+	infrastructure_usage_per_level = 1
+
+	should_auto_expand = {
+		default_auto_expand_rule = yes
+	}
+
+	economy_of_scale_ai_factor = 1.5
+	foreign_investment_ai_factor = 0.75
+    can_use_slaves = yes
+}
+
+bg_livestock_ranches = {
+	parent_group = bg_ranching
+
+	default_building = building_livestock_ranch
+
+	cash_reserves_max = 25000
+    can_use_slaves = yes
+}
+
+bg_subsistence_ranching = {
+	parent_group = bg_ranching
+
+	always_possible = yes
+
+	auto_place_buildings = yes
+
+	is_subsistence = yes
+
+	default_building = building_subsistence_farms
+
+	fired_pops_become_radical = no
+
+	hires_unemployed_only = yes
+    can_use_slaves = yes
+}
+
+
+# Plantations
+
+bg_plantations = {
+	category = rural
+
+	land_usage = rural
+
+	economy_of_scale = yes
+
+	lens = plantation
+
+	cash_reserves_max = 25000
+
+	urbanization = 5
+	infrastructure_usage_per_level = 1
+
+	should_auto_expand = {
+		default_auto_expand_rule = yes
+	}
+
+	economy_of_scale_ai_factor = 1.5
+	foreign_investment_ai_factor = 1.25
+    can_use_slaves = yes
+}
+
+bg_coffee_plantations = {
+	parent_group = bg_plantations
+
+	default_building = building_coffee_plantation
+    can_use_slaves = yes
+}
+
+
+bg_cotton_plantations = {
+	parent_group = bg_plantations
+
+	default_building = building_cotton_plantation
+    can_use_slaves = yes
+}
+
+bg_silk_plantations = {
+	parent_group = bg_plantations
+
+	default_building = building_silk_plantation
+    can_use_slaves = yes
+}
+
+bg_dye_plantations = {
+	parent_group = bg_plantations
+
+	default_building = building_dye_plantation
+    can_use_slaves = yes
+}
+
+bg_opium_plantations = {
+	parent_group = bg_plantations
+
+	default_building = building_opium_plantation
+    can_use_slaves = yes
+}
+
+bg_tea_plantations = {
+	parent_group = bg_plantations
+
+	default_building = building_tea_plantation
+    can_use_slaves = yes
+}
+
+bg_tobacco_plantations = {
+	parent_group = bg_plantations
+
+	default_building = building_tobacco_plantation
+    can_use_slaves = yes
+}
+
+bg_sugar_plantations = {
+	parent_group = bg_plantations
+
+	default_building = building_sugar_plantation
+    can_use_slaves = yes
+}
+
+bg_banana_plantations = {
+	parent_group = bg_plantations
+
+	default_building = building_banana_plantation
+    can_use_slaves = yes
+}
+
+# All Resource extraction, basically everything that is capped by resources
+
+bg_extraction = {
+	category = rural
+
+	capped_by_resources = yes
+
+	economy_of_scale = yes
+
+	cash_reserves_max = 25000
+    can_use_slaves = yes
+}
+
+# Mining
+
+bg_mining = {
+	parent_group = bg_extraction
+
+	lens = mine
+
+	urbanization = 10
+	infrastructure_usage_per_level = 2
+
+	should_auto_expand = {
+		default_auto_expand_rule = yes
+	}
+
+	economy_of_scale_ai_factor = 2.0
+	foreign_investment_ai_factor = 1.0
+    can_use_slaves = yes
+}
+
+bg_gold_fields = {
+	parent_group = bg_mining
+
+	auto_place_buildings = yes
+
+	discoverable_resource = yes
+
+	depletable_resource = yes
+
+	always_self_owning = yes
+
+	pays_taxes = no
+
+	infrastructure_usage_per_level = 0
+
+	default_building = building_gold_fields
+
+	fired_pops_become_radical = no
+    can_use_slaves = yes
+}
+
+bg_gold_mining = {
+	parent_group = bg_mining
+
+	default_building = building_gold_mine
+
+    can_use_slaves = yes
+}
+
+bg_coal_mining = {
+	parent_group = bg_mining
+
+	default_building = building_coal_mine
+
+    can_use_slaves = yes
+}
+
+bg_iron_mining = {
+	parent_group = bg_mining
+
+	default_building = building_iron_mine
+
+    can_use_slaves = yes
+}
+
+bg_lead_mining = {
+	parent_group = bg_mining
+
+	default_building = building_lead_mine
+
+    can_use_slaves = yes
+}
+
+bg_sulfur_mining = {
+	parent_group = bg_mining
+
+	default_building = building_sulfur_mine
+
+    can_use_slaves = yes
+}
+
+# Logging
+
+bg_logging = {
+	parent_group = bg_extraction
+
+
+	default_building = building_logging_camp
+
+	lens = forestry
+
+	urbanization = 5
+	infrastructure_usage_per_level = 1
+
+	should_auto_expand = {
+		default_auto_expand_rule = yes
+	}
+
+	economy_of_scale_ai_factor = 1.5
+	foreign_investment_ai_factor = 1.0
+    can_use_slaves = yes
+}
+
+bg_rubber = {
+	parent_group = bg_extraction
+
+
+	discoverable_resource = yes
+
+	depletable_resource = no
+
+	default_building = building_rubber_plantation
+
+	lens = forestry
+
+	urbanization = 5
+	infrastructure_usage_per_level = 1
+
+	should_auto_expand = {
+		default_auto_expand_rule = yes
+	}
+
+	economy_of_scale_ai_factor = 1.5
+	foreign_investment_ai_factor = 1.0
+    can_use_slaves = yes
+}
+
+# Fishing
+
+bg_whaling = {
+	parent_group = bg_extraction
+
+	default_building = building_whaling_station
+
+	lens = fishing
+
+	urbanization = 5
+	infrastructure_usage_per_level = 1
+
+	should_auto_expand = {
+		default_auto_expand_rule = yes
+	}
+
+	economy_of_scale_ai_factor = 2.0
+	foreign_investment_ai_factor = 0.75
+    can_use_slaves = yes
+}
+
+bg_fishing = {
+	parent_group = bg_extraction
+
+	default_building = building_fishing_wharf
+
+	lens = fishing
+
+	urbanization = 5
+	infrastructure_usage_per_level = 1
+
+	should_auto_expand = {
+		default_auto_expand_rule = yes
+	}
+
+	economy_of_scale_ai_factor = 1.5
+	foreign_investment_ai_factor = 0.75
+    can_use_slaves = yes
+}
+
+# Oil Extraction
+
+bg_oil_extraction = {
+	parent_group = bg_extraction
+
+	discoverable_resource = yes
+
+	default_building = building_oil_rig
+
+	lens = mine
+
+	urbanization = 10
+	infrastructure_usage_per_level = 2
+
+	should_auto_expand = {
+		default_auto_expand_rule = yes
+	}
+
+	economy_of_scale_ai_factor = 2.0
+	foreign_investment_ai_factor = 1.0
+    can_use_slaves = yes
+}
+
+# Service
+
+bg_service = {
+	category = urban
+
+	land_usage = urban
+
+	always_possible = yes
+
+	auto_place_buildings = yes
+
+	always_self_owning = yes
+
+	economy_of_scale = yes
+
+	default_building = building_urban_center
+
+	cash_reserves_max = 25000
+    can_use_slaves = yes
+}
+
+bg_urban_facilities = {
+	category = urban
+
+	lens = development
+
+	always_possible = yes
+
+	economy_of_scale = yes
+
+	cash_reserves_max = 25000
+
+	urbanization = 20
+	infrastructure_usage_per_level = 2
+
+	should_auto_expand = {
+		default_auto_expand_rule = yes
+	}
+
+	economy_of_scale_ai_factor = 2.0
+	foreign_investment_ai_factor = 0.25
+
+    can_use_slaves = yes
+}
+
+bg_arts = {
+	parent_group = bg_urban_facilities
+	infrastructure_usage_per_level = 0.5
+    can_use_slaves = yes
+}
+
+bg_power = {
+	category = development
+
+	lens = development
+
+	always_possible = yes
+
+	economy_of_scale = yes
+
+	cash_reserves_max = 25000
+
+	should_auto_expand = {
+		default_auto_expand_rule = yes
+	}
+
+	economy_of_scale_ai_factor = 1.5
+	foreign_investment_ai_factor = 0.5
+
+	infrastructure_usage_per_level = 2
+
+	urbanization = 10
+    can_use_slaves = yes
+}
+
+# Government
+
+bg_government = {
+	category = development
+
+	always_possible = yes
+
+	is_government_funded = yes
+
+	economy_of_scale = yes
+
+	lens = development
+
+	urbanization = 20
+	infrastructure_usage_per_level = 1
+
+	economy_of_scale_ai_factor = 2.0
+
+    can_use_slaves = yes
+}
+
+bg_technology = {
+	parent_group = bg_government
+    can_use_slaves = yes
+}
+
+bg_bureaucracy = {
+	parent_group = bg_government
+    can_use_slaves = yes
+}
+
+bg_trade = {
+	parent_group = bg_private_infrastructure
+
+	stateregion_max_level = no
+
+	lens = trade
+
+	subsidized = no
+
+	has_trade_revenue = yes
+
+	economy_of_scale = no
+
+	default_building = building_trade_center
+
+
+	infrastructure_usage_per_level = 0.5
+    can_use_slaves = yes
+}
+
+# Needed for autonomous investment to track investments separately from other ownership buildings
+bg_financial_districts = {
+	parent_group = bg_owner_buildings
+
+	urbanization = 5
+    can_use_slaves = yes
+}
+
+# Needed for autonomous investment to track investments separately from other ownership buildings
+bg_manor_houses = {
+	parent_group = bg_owner_buildings
+
+	infrastructure_usage_per_level = 0.0
+    can_use_slaves = yes
+}
+
+bg_company_headquarter = {
+	parent_group = bg_owner_buildings
+
+	company_headquarter = yes
+
+	urbanization = 5
+    can_use_slaves = yes
+}
+
+bg_company_regional_headquarter = {
+	parent_group = bg_owner_buildings
+
+	regional_company_headquarter = yes
+
+	urbanization = 5
+    can_use_slaves = yes
+}
+
+bg_owner_buildings = {
+	parent_group = bg_urban_facilities
+
+	min_productivity_to_hire = 10.0
+
+	category = urban
+
+	lens = trade
+
+	always_possible = yes
+
+
+	auto_place_buildings = yes
+
+	owns_other_buildings = yes
+
+	always_self_owning = yes
+
+	ignores_productivity_when_hiring = yes
+
+	proportionality_limit = 1.0
+
+	economy_of_scale = no
+
+	default_building = building_financial_district
+
+	cash_reserves_max = 10000
+
+	urbanization = 0
+
+	infrastructure_usage_per_level = 0.1
+
+	fired_pops_become_radical = no
+
+	should_auto_expand = {
+		always = no
+	}
+    can_use_slaves = yes
+}
+
+# Infrastructure
+
+bg_infrastructure = {
+	category = development
+
+	always_possible = yes
+
+	lens = development
+
+	stateregion_max_level = yes
+
+	economy_of_scale_ai_factor = 1.5
+	foreign_investment_ai_factor = 0.75
+
+    can_use_slaves = yes
+}
+
+bg_public_infrastructure = {
+	parent_group = bg_infrastructure
+
+	is_government_funded = yes
+
+	urbanization = 5
+    can_use_slaves = yes
+}
+
+bg_construction = {
+	parent_group = bg_public_infrastructure
+
+	infrastructure_usage_per_level = 2
+
+	lens = development
+
+	is_government_funded = yes
+
+
+	urbanization = 5
+
+	economy_of_scale_ai_factor = 5.0
+    can_use_slaves = yes
+}
+
+bg_private_infrastructure = {
+	parent_group = bg_infrastructure
+
+	is_government_funded = no
+	subsidized = yes
+
+	cash_reserves_max = 25000
+
+	urbanization = 5
+    can_use_slaves = yes
+}
+
+bg_canals = {
+	parent_group = bg_infrastructure
+	lens = special
+
+	is_government_funded = yes
+	inheritable_construction = yes
+
+	urbanization = 100
+    can_use_slaves = yes
+}
+
+bg_monuments = {
+	parent_group = bg_government
+	lens = special
+	inheritable_construction = yes
+	economy_of_scale = no
+    can_use_slaves = yes
+}
+
+# Military
+
+bg_military = {
+	category = development
+
+	always_possible = yes
+
+	is_military = yes
+
+	is_government_funded = yes
+
+	infrastructure_usage_per_level = 0.2
+
+	lens = development
+
+	urbanization = 2
+
+}
+
+bg_army = {
+	parent_group = bg_military
+}
+
+bg_conscription = {
+	parent_group = bg_army
+	urbanization = 0
+
+	fired_pops_become_radical = no
+    can_use_slaves = yes
+}
+
+bg_navy = {
+	parent_group = bg_military
+}
+
+bg_skyscraper = {
+	parent_group = bg_government
+	economy_of_scale = no
+    can_use_slaves = yes
+}
+
+bg_monuments_hidden = {
+	always_possible = yes
+	is_shown_in_outliner = no
+    can_use_slaves = yes
+}

--- a/common/buildings/05_military.txt
+++ b/common/buildings/05_military.txt
@@ -1,0 +1,73 @@
+﻿############ BARRACKS
+
+building_barracks = {
+	building_group = bg_army
+	recruits_combat_units = yes
+	icon = "gfx/interface/icons/building_icons/building_barracks.dds"
+	city_type = city
+
+	has_max_level = yes
+
+	levels_per_mesh = 25
+
+	unlocking_technologies = {
+		standing_army
+	}
+
+	production_method_groups = {
+		pmg_training
+	}
+
+	required_construction = construction_cost_very_low
+
+	background = "gfx/interface/icons/building_icons/backgrounds/building_panel_bg_military.dds"
+}
+
+building_conscription_center = {
+        building_group = bg_conscription
+        buildable = no
+        expandable = no
+        downsizeable = no
+        slaves_role = soldiers
+
+        has_max_level = yes
+
+	levels_per_mesh = 0
+	residence_points_per_level = 0
+	city_type = none
+
+	recruits_combat_units = yes
+	icon = "gfx/interface/icons/building_icons/building_conscription_center.dds"
+
+	production_method_groups = {
+		pmg_training_conscription
+	}
+
+	background = "gfx/interface/icons/building_icons/backgrounds/building_panel_bg_military.dds"
+}
+
+building_naval_base = {
+	building_group = bg_navy
+	recruits_combat_units = yes
+	city_type = port
+	levels_per_mesh = 25
+
+	has_max_level = yes
+
+	icon = "gfx/interface/icons/building_icons/naval_base.dds"
+	naval = yes
+	unlocking_technologies = { admiralty }
+
+	production_method_groups = {
+		pmg_naval_theory
+	}
+
+	required_construction = construction_cost_very_low
+
+	# Can only build naval bases on the coast
+	potential = {
+		is_coastal = yes
+	}
+
+	background = "gfx/interface/icons/building_icons/backgrounds/building_panel_bg_military.dds"
+}


### PR DESCRIPTION
## Summary
- set `can_use_slaves = yes` on building groups so laborer work may be filled by slaves
- allow conscription centers to hire slave soldiers
- removed unused `slaves_role` settings in groups

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687579c00b64832e87d18d10c9341d6b