### PR TITLE
Set default laws for chartered companies

### DIFF
--- a/common/on_actions/99_MP_on_actions.txt
+++ b/common/on_actions/99_MP_on_actions.txt
@@ -1,0 +1,11 @@
+on_game_started_after_lobby = {
+    effect = {
+        every_country = {
+            limit = { has_government_type = gov_chartered_company }
+            activate_law = law_type:law_corporatocracy
+            activate_law = law_type:law_dividend_taxation
+            activate_law = law_type:law_corporate_state
+            activate_law = law_type:law_corporate_economy
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a new `on_game_started_after_lobby` on action
- ensure every chartered company activates Corporatocracy, Dividend Taxation, Corporate State and Corporate Economy at the start of a game

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68758b079aac832eb035cde675414bee